### PR TITLE
Adding support to preemptible sweeps

### DIFF
--- a/example/conf/config.yaml
+++ b/example/conf/config.yaml
@@ -10,6 +10,7 @@ hydra:
                 goal: minimize
             method: bayes
             num_agents: 2
+            preemptible: true
 
 x: 1
 y: 1

--- a/hydra_plugins/hydra_wandb_sweeper/config.py
+++ b/hydra_plugins/hydra_wandb_sweeper/config.py
@@ -16,6 +16,7 @@ class WandbConfig:
     entity: typing.Optional[str] = None
     project: typing.Optional[str] = None
     early_terminate: typing.Optional[omegaconf.DictConfig] = omegaconf.DictConfig({})
+    preemptible: typing.Optional[bool] = False
 
 
 @dataclasses.dataclass

--- a/hydra_plugins/hydra_wandb_sweeper/wandb_sweeper.py
+++ b/hydra_plugins/hydra_wandb_sweeper/wandb_sweeper.py
@@ -159,7 +159,8 @@ class WandbSweeper(sweeper.Sweeper):
     def wandb_task(self, base_config, task_function, count):
         def run():
             with wandb.init(resume=self._preemptible) as run:
-                wandb.mark_preempting()
+                if self._preemptible:
+                    wandb.mark_preempting()
                 run_id = run.id
                 override_config = run.config
             override_config = omegaconf.DictConfig(override_config.as_dict())

--- a/hydra_plugins/hydra_wandb_sweeper/wandb_sweeper.py
+++ b/hydra_plugins/hydra_wandb_sweeper/wandb_sweeper.py
@@ -88,7 +88,8 @@ class WandbSweeper(sweeper.Sweeper):
     def __init__(self, wandb_sweep_config: omegaconf.DictConfig) -> None:
         self.wandb_sweep_config = wandb_sweep_config
         self._sweep_id = None
-        self.agent_run_count = self.wandb_sweep_config["count"]
+        self._preemptible = wandb_sweep_config["preemptible"]
+        self.agent_run_count = self.wandb_sweep_config.get["count"]
 
         self.job_idx = itertools.count(0)
 
@@ -157,7 +158,8 @@ class WandbSweeper(sweeper.Sweeper):
 
     def wandb_task(self, base_config, task_function, count):
         def run():
-            with wandb.init() as run:
+            with wandb.init(resume=self._preemptible) as run:
+                wandb.mark_preempting()
                 run_id = run.id
                 override_config = run.config
             override_config = omegaconf.DictConfig(override_config.as_dict())


### PR DESCRIPTION
Addresses: #1 

WandB sweeps doesn't allow passing run-ids to resume a preemptied sweep. However, it is done by marking a run preemptible if you know your run is about to be pre-emptied (Ref: https://docs.wandb.ai/guides/track/advanced/resuming#preemptible-sweeps)

In this plugin, to mark all your agents to be preemptible, pass `preemptible: True` in the `wandb_sweep_config` section.

Example: https://github.com/captain-pool/hydra-wandb-sweeper/blob/22ada6ff301906a12e20267c0890c051d9aa3e31/example/conf/config.yaml#L14